### PR TITLE
Fix too short timeout in unit test

### DIFF
--- a/test/NLog.MailKit.Tests/MailTargetTests.cs
+++ b/test/NLog.MailKit.Tests/MailTargetTests.cs
@@ -66,7 +66,7 @@ namespace NLog.MailKit.Tests
             var logger = LogManager.GetLogger("logger1");
             logger.Info("hello first mail!");
 
-            countdownEvent.Wait(TimeSpan.FromSeconds(10));
+            countdownEvent.Wait(TimeSpan.FromSeconds(50));
 
             Assert.Equal(1, messageStore.RecievedMessages.Count);
             var recievedMesssage = messageStore.RecievedMessages[0];


### PR DESCRIPTION
## Proposed changes

Fixes unstable tests by increasing timeout for receiving mail messages.

## Related issues

I had similar error as a part of #28.