### PR TITLE
Fix issue 43. Marked the method Write(AsyncLogEventInfo[]) as obsolete.

### DIFF
--- a/src/NLog.MailKit/MailTarget.cs
+++ b/src/NLog.MailKit/MailTarget.cs
@@ -275,6 +275,7 @@ namespace NLog.MailKit
         /// optimize batch writes.
         /// </summary>
         /// <param name="logEvents">Logging events to be written out.</param>
+        [Obsolete("Write(AsyncLogEventInfo[]) is obsolete. Override Write(IList{AsyncLogEventInfo} logEvents) instead.", true)]
         protected override void Write(AsyncLogEventInfo[] logEvents)
         {
             Write((IList<AsyncLogEventInfo>)logEvents);


### PR DESCRIPTION
Fix issue 43. Marked the method Write(AsyncLogEventInfo[]) as obsolete. Using the same will now produce a compilation error..

Can someone please take a look into this PR and let me know if any other changes required for the same.. Thanks..