### PR TITLE
Support SmtpAuthenticationMode.Ntlm

### DIFF
--- a/src/NLog.MailKit/MailTarget.cs
+++ b/src/NLog.MailKit/MailTarget.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
 using System.Text;
 using MailKit.Net.Smtp;
 using MailKit.Security;
@@ -446,6 +447,19 @@ namespace NLog.MailKit
                     var oauth2 = new SaslMechanismOAuth2(userName, oauth2Token);
                     client.Authenticate(oauth2);
                 }
+                else if (smtpAuthentication == SmtpAuthenticationMode.Ntlm)
+                {
+                    var userName = RenderLogEvent(SmtpUserName, lastEvent);
+                    var password = RenderLogEvent(SmtpPassword, lastEvent);
+                    if (!string.IsNullOrWhiteSpace(userName))
+                    {
+                        client.Authenticate(new SaslMechanismNtlm(userName, password));
+                    }
+                    else
+                    {
+                        client.Authenticate(new SaslMechanismNtlm(CredentialCache.DefaultNetworkCredentials));
+                    }
+                }
 
                 client.Send(message);
                 InternalLogger.Trace("{0}: Sending mail done. Disconnecting", this);
@@ -535,17 +549,12 @@ namespace NLog.MailKit
                 throw new NLogConfigurationException("MailTarget - To address is required");
             }
 
-            var smtpAuthentication = RenderLogEvent(SmtpAuthentication, LogEventInfo.CreateNullEvent());
-            if (smtpAuthentication == SmtpAuthenticationMode.Ntlm)
-            {
-                throw new NLogConfigurationException("MailTarget - SmtpAuthentication NTLM not yet supported");
-            }
-
             if (IsEmptyLayout(PickupDirectoryLocation) && IsEmptyLayout(SmtpServer))
             {
                 throw new NLogConfigurationException("MailTarget - SmtpServer is required");
             }
 
+            var smtpAuthentication = RenderLogEvent(SmtpAuthentication, LogEventInfo.CreateNullEvent());
             if (smtpAuthentication == SmtpAuthenticationMode.OAuth2 && (IsEmptyLayout(SmtpUserName) || IsEmptyLayout(SmtpPassword)))
             {
                 throw new NLogConfigurationException("MailTarget - SmtpUserName (OAuth UserName) and SmtpPassword (OAuth AccessToken) is required when SmtpAuthentication = OAuth2");

--- a/test/NLog.MailKit.Tests/UnitTests/MailTargetTests.cs
+++ b/test/NLog.MailKit.Tests/UnitTests/MailTargetTests.cs
@@ -190,27 +190,6 @@ namespace NLog.MailKit.Tests.UnitTests
         }
 
         [Fact]
-        public void MailTargetInitialize_WithSmtpAuthenticationModeNtlm_ThrowsConfigException()
-        {
-            var mmt = new MailTarget
-            {
-                From = "foo@bar.com",
-                To = "bar@bar.com",
-                Subject = "Hello from NLog",
-                SmtpServer = "server1",
-                SmtpPort = 27,
-                SmtpAuthentication = SmtpAuthenticationMode.Ntlm,
-            };
-
-            Assert.Throws<NLogConfigurationException>(() =>
-                new LogFactory().Setup().LoadConfiguration(cfg =>
-                {
-                    cfg.Configuration.AddRuleForAllLevels(mmt);
-                })
-            );
-        }
-
-        [Fact]
         public void MailTargetInitialize_WithSmtpAuthenticationModeOAuth2_ThrowsConfigException()
         {
             var mmt = new MailTarget


### PR DESCRIPTION
With help from Mailkit SaslMechanismNtlm introduced with Mailkit ver. 2.5

NTLM without providing username / password probably only works on Windows.